### PR TITLE
Update reproducing_registered_reports.bib

### DIFF
--- a/reproducing_registered_reports.bib
+++ b/reproducing_registered_reports.bib
@@ -1,4 +1,18 @@
+@article{brinckman2019computing,
+  title={Computing environments for reproducibility: Capturing the “Whole Tale”},
+  author={Brinckman, Adam and Chard, Kyle and Gaffney, Niall and Hategan, Mihael and Jones, Matthew B and Kowalik, Kacper and Kulasekaran, Sivakumar and Lud{\"a}scher, Bertram and Mecum, Bryce D and Nabrzyski, Jarek and others},
+  journal={Future Generation Computer Systems},
+  volume={94},
+  pages={854--867},
+  year={2019},
+  publisher={Elsevier}
+}
 
+@article{ragan2018binder,
+  title={Binder 2.0-Reproducible, interactive, sharable environments for science at scale},
+  author={Ragan-Kelley, Benjamin and Willing, Carol},
+  year={2018}
+}
 @article{campbell_self-esteem_2018,
   series = {Replication of {{Critical Findings}} in {{Personality Psychology}}},
   title = {Self-Esteem, Relationship Threat, and Dependency Regulation: {{Independent}} Replication of {{Murray}}, {{Rose}}, {{Bellavia}}, {{Holmes}}, and {{Kusche}} (2002) {{Study}} 3},


### PR DESCRIPTION
Added two citations --brinckman2019computing and ragan2018binder -- to allow for discussing Binder and Whole Tale in the paper